### PR TITLE
fix(security): patch CVE-2025-66478 React2Shell vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "eslint-config-next": "^15.4.2",
+    "eslint-config-next": "^15.4.8",
     "framer-motion": "^12.23.6",
-    "next": "^15.4.2",
+    "next": "^15.4.8",
     "nodemailer": "^6.9.3",
     "react": "^19.1.0",
     "react-device-detect": "^2.2.3",


### PR DESCRIPTION
Update Next.js from 15.4.2 to 15.4.8 to address the critical
React2Shell RCE vulnerability (CVSS 10.0) affecting React Server
Components. Also update eslint-config-next to matching version.

See: https://nextjs.org/blog/CVE-2025-66478