### PR TITLE
fix(ci): target master branch instead of main in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
The default branch is master, not main. CI workflow was never triggering because it was listening for pushes/PRs to a non-existent main branch.

https://claude.ai/code/session_016xShvHXZQFQ6cTdTCKeUk1